### PR TITLE
Remove trailing newlines from stdout by default

### DIFF
--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -69,7 +69,7 @@ impl CmdArgument for Vec<String> {
 /// use stir::cmd;
 ///
 /// let output: String = cmd!(["echo", "foo"]);
-/// assert_eq!(output, "foo\n");
+/// assert_eq!(output, "foo");
 /// ```
 #[rustversion::since(1.51)]
 impl<const N: usize> CmdArgument for [&str; N] {

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -50,8 +50,14 @@ impl CmdOutput for () {
 ///
 /// let output: String = cmd!("echo foo");
 /// assert_eq!(output, "foo"); // trims '\n' character at the end
+/// # #[rustversion::since(1.51)]
+/// # fn test() {
 /// let output: String = cmd!("echo", ["\nfoo "]);
 /// assert_eq!(output, "\nfoo "); // does not trim other whitespace
+/// # }
+/// # #[rustversion::before(1.51)]
+/// # fn test() {}
+/// # test();
 /// ```
 impl CmdOutput for String {
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,9 @@
 //! ```
 //! use stir::{cmd, Exit};
 //!
-//! let (Exit(status), stdout): (_, String) = cmd!("which ls");
+//! let (Exit(status), stdout): (_, String) = cmd!("echo foo");
 //! assert_eq!(status.code(), Some(0));
-//! assert_eq!(stdout, "/usr/bin/ls");
+//! assert_eq!(stdout, "foo");
 //! ```
 //!
 //! See the implementations for [`CmdOutput`] for all the supported types.


### PR DESCRIPTION
This is an experiment to see how it'd look like if captured `stdout` would be trimmed by default. This is a maybe more convenient, but maybe less safe alternative to #32.