### PR TITLE
Provide newtype wrappers for trimmed & untrimmed stdout

### DIFF
--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -66,9 +66,9 @@ impl CmdArgument for Vec<String> {
 /// process as arguments, **without** splitting them by whitespace.
 ///
 /// ```
-/// use stir::cmd;
+/// use stir::{cmd, Stdout};
 ///
-/// let output: String = cmd!(["echo", "foo"]);
+/// let Stdout(output) = cmd!(["echo", "foo"]);
 /// assert_eq!(output, "foo\n");
 /// ```
 #[rustversion::since(1.51)]


### PR DESCRIPTION
The idea is that we remove the impl for `CmdOutput` for `String`, but add two new ones for `StdoutTrimmed` and `StdoutUntrimmed`. They are both newtype wrappers around `String`. That way we would force users to make a decision about whether they want trimmed or untrimmed output. The current `String` impl (on master) does *not* trim. But that's not good, since in *most* cases, users probably would want trimmed output. On the other hand, making the `String` impl trim by default is possible, but also really surprising. So this is maybe the best option.

It'd look like this:
``` rust
let StdoutTrimmed(ls_executable) = cmd!("which ls");
let StdoutUntrimmed(unmodified_output) = cmd!("some command");
```