### PR TITLE
Remove stir::Result

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,13 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: clippy, rustfmt
-
       # An issue with BSD Tar causes sporadic failures on macOS.
       # c.f https://github.com/actions/cache/issues/403
       - name: Install GNU Tar
@@ -84,6 +77,11 @@ jobs:
             echo '1.51.0' > rust-toolchain
             cargo install --path .
           fi
+
+      - name: Install clippy and rustfmt
+        run: |
+          echo '${{ matrix.rust }}' > rust-toolchain
+          rustup component add clippy rustfmt
 
       - name: Info
         run: |

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -37,7 +37,7 @@ impl CmdArgument for String {
 ///
 /// ```
 /// use std::path::PathBuf;
-/// use stir::cmd_unit;
+/// use stir::*;
 ///
 /// cmd_unit!("touch", vec!["filename with spaces"]);
 /// assert!(PathBuf::from("filename with spaces").exists());
@@ -66,7 +66,7 @@ impl CmdArgument for Vec<String> {
 /// process as arguments, **without** splitting them by whitespace.
 ///
 /// ```
-/// use stir::cmd;
+/// use stir::*;
 ///
 /// let output: String = cmd!(["echo", "foo"]);
 /// assert_eq!(output, "foo\n");
@@ -110,7 +110,7 @@ pub struct LogCommand;
 /// (This is similar `bash`'s `-x` option.)
 ///
 /// ```
-/// use stir::{cmd_unit, LogCommand};
+/// use stir::*;
 ///
 /// cmd_unit!(LogCommand, "echo foo");
 /// // writes '+ echo foo' to stderr

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -57,8 +57,8 @@ impl CmdOutput for String {
 }
 
 /// To turn all possible panics of [`cmd!`] into [`std::result::Result::Err`]s
-/// you can use a return type of `Result<T, Error>`. `T` can be any type that
-/// implements [`CmdOutput`] and [`Error`] is stir's custom error type.
+/// you can use a return type of `Result<T, stir::Error>`. `T` can be any type that
+/// implements [`CmdOutput`].
 impl<T> CmdOutput for Result<T, Error>
 where
     T: CmdOutput,

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -12,7 +12,7 @@ use std::process::ExitStatus;
 /// [`ExitStatus`]:
 ///
 /// ```
-/// use stir::{cmd, Exit};
+/// use stir::*;
 ///
 /// let (stdout, Exit(status)) = cmd!("echo foo");
 /// let _: String = stdout;
@@ -109,7 +109,7 @@ pub struct Exit(pub ExitStatus);
 /// retrieve the [`ExitStatus`] of the child process:
 ///
 /// ```
-/// use stir::{cmd, Exit};
+/// use stir::*;
 ///
 /// let Exit(status) = cmd!("echo foo");
 /// assert!(status.success());
@@ -119,7 +119,7 @@ pub struct Exit(pub ExitStatus);
 /// result in neither a panic nor a [`std::result::Result::Err`]:
 ///
 /// ```
-/// use stir::{cmd, Exit};
+/// use stir::*;
 ///
 /// let Exit(status) = cmd!("false");
 /// assert_eq!(status.code(), Some(1));
@@ -150,7 +150,7 @@ pub struct Stderr(pub String);
 /// [`Stderr`] allows to capture the `stderr` of a child process:
 ///
 /// ```
-/// use stir::{cmd, Exit, Stderr};
+/// use stir::*;
 ///
 /// // (`Exit` is used here to suppress panics caused by `ls`
 /// // terminating with a non-zero exit code.)

--- a/src/context_integration_tests.rs
+++ b/src/context_integration_tests.rs
@@ -4,7 +4,7 @@ fn main() {
         use executable_path::executable_path;
         use gag::BufferRedirect;
         use std::io::{self, Read};
-        use stir::cmd;
+        use stir::*;
 
         fn with_gag<F>(mk_buf: fn() -> io::Result<BufferRedirect>, f: F) -> String
         where

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 use std::{fmt::Display, io, process::ExitStatus};
 
-pub type Result<T> = std::result::Result<T, Error>;
-
 #[derive(PartialEq, Debug, Clone)]
 pub enum Error {
     NoArgumentsGiven,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,10 +132,9 @@
 //! assert_eq!(exit_status.code(), Some(1));
 //! ```
 //!
-//! Or you can turn the panics into [`std::result::Result::Err`]s
-//! by fixing the return type of [`cmd!`] to `Result<T>`, where
-//! `T` is any type that implements [`CmdOutput`] and
-//! [`Result`] is stir's custom result type, which uses [`Error`].
+//! You can also turn all panics into [`std::result::Result::Err`]s
+//! by fixing the return type of [`cmd!`] to `Result<T, stir::Error>`, where
+//! `T` is any type that implements [`CmdOutput`].
 //! Here's some examples:
 //!
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! it easy to run commands from rust programs.
 //!
 //! ```
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! let stdout: String = cmd!("echo -n foo");
 //! assert_eq!(stdout, "foo");
@@ -15,7 +15,7 @@
 //! trait:
 //!
 //! ```
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! let stdout: String = cmd!("echo", "foo", "bar");
 //! assert_eq!(stdout, "foo bar\n");
@@ -26,7 +26,7 @@
 //! be used as arguments:
 //!
 //! ```
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! # #[rustversion::since(1.51)]
 //! # fn test() {
@@ -43,7 +43,7 @@
 //!
 //! ```
 //! use std::path::PathBuf;
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! # #[rustversion::since(1.51)]
 //! # fn test() {
@@ -59,7 +59,7 @@
 //!
 //! ```
 //! use std::path::PathBuf;
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! let _: String = cmd!("touch", vec!["filename with spaces"]);
 //! assert!(PathBuf::from("filename with spaces").exists());
@@ -75,7 +75,7 @@
 //! child process writes to `stdout`:
 //!
 //! ```
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! let output: String = cmd!("echo foo");
 //! assert_eq!(output, "foo\n");
@@ -88,7 +88,7 @@
 //! as the return value:
 //!
 //! ```
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! let () = cmd!("touch foo");
 //! ```
@@ -98,7 +98,7 @@
 //! type down to `()`:
 //!
 //! ```
-//! use stir::cmd_unit;
+//! use stir::*;
 //!
 //! cmd_unit!("touch foo");
 //! ```
@@ -116,7 +116,7 @@
 //! For example:
 //!
 //! ``` should_panic
-//! use stir::cmd_unit;
+//! use stir::*;
 //!
 //! // panics with "false:\n  exited with exit code: 1"
 //! cmd_unit!("false");
@@ -126,7 +126,7 @@
 //! a return type of [`cmd!`]:
 //!
 //! ```
-//! use stir::{cmd, Exit};
+//! use stir::*;
 //!
 //! let Exit(exit_status) = cmd!("false");
 //! assert_eq!(exit_status.code(), Some(1));
@@ -138,7 +138,7 @@
 //! Here's some examples:
 //!
 //! ```
-//! use stir::cmd;
+//! use stir::*;
 //!
 //! let result: Result<(), stir::Error> = cmd!("false");
 //! let error_message = format!("{}", result.unwrap_err());


### PR DESCRIPTION
Hopefully this would make using `stir` easier, since users can just do `use stir::*;`, without having `stir::Result` shadow `std::result::Result`. And the benefits of having `stir::Result` aren't that big.

There still is `stir::Error`, which can also clash with other error types. I'm inclined to leave that in, at least for now.