### PR TITLE
Switch to cmd_result!

### DIFF
--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -58,27 +58,6 @@ impl CmdOutput for String {
     }
 }
 
-/// To turn all possible panics of [`cmd!`] into [`std::result::Result::Err`]s
-/// you can use a return type of `Result<T, stir::Error>`. `T` can be any type that
-/// implements [`CmdOutput`].
-impl<T> CmdOutput for Result<T, Error>
-where
-    T: CmdOutput,
-{
-    #[doc(hidden)]
-    fn prepare_config(config: &mut Config) {
-        T::prepare_config(config);
-    }
-
-    #[doc(hidden)]
-    fn from_run_result(config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
-        Ok(match result {
-            Ok(_) => T::from_run_result(config, result),
-            Err(error) => Err(error),
-        })
-    }
-}
-
 macro_rules! tuple_impl {
     ($($generics:ident,)+) => {
         impl<$($generics),+> CmdOutput for ($($generics,)+)
@@ -125,7 +104,7 @@ pub struct Exit(pub ExitStatus);
 ///
 /// let Exit(status) = cmd!("false");
 /// assert_eq!(status.code(), Some(1));
-/// let result: Result<Exit, stir::Error> = cmd!("false");
+/// let result: Result<Exit, stir::Error> = cmd_result!("false");
 /// assert!(result.is_ok());
 /// assert_eq!(result.unwrap().0.code(), Some(1));
 /// ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,14 @@ impl Error {
     }
 }
 
+#[doc(hidden)]
+pub fn panic_on_error<T>(result: Result<T, Error>) -> T {
+    match result {
+        Ok(t) => t,
+        Err(error) => panic!("cmd!: {}", error),
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -880,7 +880,7 @@ mod tests {
         }
 
         #[test]
-        fn result_of_exit() {
+        fn failing_commands_return_oks_when_exit_status_is_captured() {
             let result: Result<Exit, Error> = cmd_result!("false");
             assert!(!result.unwrap().0.success());
         }
@@ -929,8 +929,9 @@ mod tests {
 
         #[test]
         fn three_tuples() {
-            let (Stderr(_), output, Exit(status)): (Stderr, String, Exit) = cmd!("echo foo");
-            assert_eq!(output, "foo\n");
+            let (Stderr(stderr), stdout, Exit(status)): (Stderr, String, Exit) = cmd!("echo foo");
+            assert_eq!(stderr, "");
+            assert_eq!(stdout, "foo\n");
             assert_eq!(status.code(), Some(0));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,6 @@
 //! idiomatic way, for example:
 //!
 //! ```
-//! use std::path::Path;
 //! use stir::*;
 //!
 //! fn build() -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -862,6 +862,12 @@ mod tests {
             assert!(!exit_status.success());
             assert_eq!(exit_status.code(), Some(42));
         }
+
+        #[test]
+        fn result_of_exit() {
+            let result: Result<Exit, Error> = cmd_result!("false");
+            assert!(!result.unwrap().0.success());
+        }
     }
 
     mod tuple_outputs {
@@ -910,6 +916,26 @@ mod tests {
             let (Stderr(_), output, Exit(status)): (Stderr, String, Exit) = cmd!("echo foo");
             assert_eq!(output, "foo\n");
             assert_eq!(status.code(), Some(0));
+        }
+
+        #[test]
+        fn capturing_stdout_on_errors() {
+            let (output, Exit(status)): (String, Exit) = cmd!(
+                executable_path("stir_test_helper").to_str().unwrap(),
+                vec!["output foo and exit with 42"]
+            );
+            assert!(!status.success());
+            assert_eq!(output, "foo\n");
+        }
+
+        #[test]
+        fn capturing_stderr_on_errors() {
+            let (Stderr(output), Exit(status)) = cmd!(
+                executable_path("stir_test_helper").to_str().unwrap(),
+                vec!["write to stderr and exit with 42"]
+            );
+            assert!(!status.success());
+            assert_eq!(output, "foo\n");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,22 @@
 //! let result: Result<String, stir::Error> = cmd_result!("echo foo");
 //! assert_eq!(result.unwrap(), "foo\n".to_string());
 //! ```
+//!
+//! [`cmd_result`] can also be combined with `?` to handle errors in an
+//! idiomatic way, for example:
+//!
+//! ```
+//! use std::path::Path;
+//! use stir::*;
+//!
+//! fn build() -> Result<(), Error> {
+//!     cmd_result!("which make")?;
+//!     cmd_result!("which gcc")?;
+//!     cmd_result!("which ld")?;
+//!     cmd_result!("make build")?;
+//!     Ok(())
+//! }
+//! ```
 
 mod cmd_argument;
 mod cmd_output;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -27,8 +27,7 @@ fn result_succeeding() {
 
     fn test() -> Result<(), Error> {
         // make sure 'ls' is installed
-        let result: Result<(), Error> = cmd_result!(WHICH, "ls");
-        result?;
+        cmd_result!(WHICH, "ls")?;
         Ok(())
     }
 
@@ -40,8 +39,7 @@ fn result_failing() {
     use stir::*;
 
     fn test() -> Result<(), Error> {
-        let result: Result<(), Error> = cmd_result!(WHICH, "does-not-exist");
-        result?;
+        cmd_result!(WHICH, "does-not-exist")?;
         Ok(())
     }
 
@@ -77,8 +75,7 @@ fn trimmed_stdout_and_results() {
     use stir::*;
 
     fn test() -> Result<(), Error> {
-        let result: Result<String, Error> = cmd_result!(WHICH, "ls");
-        let ls_path = result?;
+        let ls_path: String = cmd_result!(WHICH, "ls")?;
         let ls_path = ls_path.trim();
         assert!(
             PathBuf::from(&ls_path).exists(),
@@ -98,8 +95,7 @@ fn box_dyn_errors_succeeding() {
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
     fn test() -> MyResult<()> {
-        let result: Result<(), Error> = cmd_result!(WHICH, "ls");
-        result?;
+        cmd_result!(WHICH, "ls")?;
         Ok(())
     }
 
@@ -113,8 +109,7 @@ fn box_dyn_errors_failing() {
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
     fn test() -> MyResult<()> {
-        let result: Result<(), Error> = cmd_result!(WHICH, "does-not-exist");
-        result?;
+        cmd_result!(WHICH, "does-not-exist")?;
         Ok(())
     }
 
@@ -144,8 +139,7 @@ fn user_supplied_errors_succeeding() {
     }
 
     fn test() -> Result<(), Error> {
-        let result: Result<(), stir::Error> = cmd_result!(WHICH, "ls");
-        result?;
+        cmd_result!(WHICH, "ls")?;
         Ok(())
     }
 
@@ -176,8 +170,7 @@ fn user_supplied_errors_failing() {
     }
 
     fn test() -> Result<(), Error> {
-        let result: Result<(), stir::Error> = cmd_result!(WHICH, "does-not-exist");
-        result?;
+        cmd_result!(WHICH, "does-not-exist")?;
         Ok(())
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -27,7 +27,7 @@ fn result_succeeding() {
 
     fn test() -> Result<(), Error> {
         // make sure 'ls' is installed
-        let result: Result<(), Error> = cmd!(WHICH, "ls");
+        let result: Result<(), Error> = cmd_result!(WHICH, "ls");
         result?;
         Ok(())
     }
@@ -40,7 +40,7 @@ fn result_failing() {
     use stir::*;
 
     fn test() -> Result<(), Error> {
-        let result: Result<(), Error> = cmd!(WHICH, "does-not-exist");
+        let result: Result<(), Error> = cmd_result!(WHICH, "does-not-exist");
         result?;
         Ok(())
     }
@@ -77,7 +77,7 @@ fn trimmed_stdout_and_results() {
     use stir::*;
 
     fn test() -> Result<(), Error> {
-        let result: Result<String, Error> = cmd!(WHICH, "ls");
+        let result: Result<String, Error> = cmd_result!(WHICH, "ls");
         let ls_path = result?;
         let ls_path = ls_path.trim();
         assert!(
@@ -98,7 +98,7 @@ fn box_dyn_errors_succeeding() {
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
     fn test() -> MyResult<()> {
-        let result: Result<(), Error> = cmd!(WHICH, "ls");
+        let result: Result<(), Error> = cmd_result!(WHICH, "ls");
         result?;
         Ok(())
     }
@@ -113,7 +113,7 @@ fn box_dyn_errors_failing() {
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
     fn test() -> MyResult<()> {
-        let result: Result<(), Error> = cmd!(WHICH, "does-not-exist");
+        let result: Result<(), Error> = cmd_result!(WHICH, "does-not-exist");
         result?;
         Ok(())
     }
@@ -144,7 +144,7 @@ fn user_supplied_errors_succeeding() {
     }
 
     fn test() -> Result<(), Error> {
-        let result: Result<(), stir::Error> = cmd!(WHICH, "ls");
+        let result: Result<(), stir::Error> = cmd_result!(WHICH, "ls");
         result?;
         Ok(())
     }
@@ -176,7 +176,7 @@ fn user_supplied_errors_failing() {
     }
 
     fn test() -> Result<(), Error> {
-        let result: Result<(), stir::Error> = cmd!(WHICH, "does-not-exist");
+        let result: Result<(), stir::Error> = cmd_result!(WHICH, "does-not-exist");
         result?;
         Ok(())
     }


### PR DESCRIPTION
This PR remove the `CmdOutput` impl for `Result` and instead adds a `cmd_result` variant that pins down the return type to `Result<T, Error> where T: CmdOutput`. I'm not sure this should be merged. It's an alternative to #35.