### PR TITLE
Trimmed and untrimmed stdout

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,5 +25,5 @@ fmt:
 forbidden-words:
   ! grep -rni \
     'dbg!\|fixme\|todo\|ignore' \
-    src
+    src tests
   @echo No forbidden words found

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -69,8 +69,8 @@ impl CmdArgument for Vec<String> {
 /// ```
 /// use stir::*;
 ///
-/// let StdoutUntrimmed(output) = cmd!(["echo", "foo"]);
-/// assert_eq!(output, "foo\n");
+/// let StdoutTrimmed(output) = cmd!(["echo", "foo"]);
+/// assert_eq!(output, "foo");
 /// ```
 #[rustversion::since(1.51)]
 impl<const N: usize> CmdArgument for [&str; N] {
@@ -134,8 +134,8 @@ pub struct CurrentDir<T: AsRef<Path>>(pub T);
 ///
 /// # #[cfg(target_os = "linux")]
 /// # {
-/// let StdoutUntrimmed(output) = cmd!("pwd", CurrentDir("/tmp"));
-/// assert_eq!(output, "/tmp\n");
+/// let StdoutTrimmed(output) = cmd!("pwd", CurrentDir("/tmp"));
+/// assert_eq!(output, "/tmp");
 /// # }
 /// ```
 ///

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -69,7 +69,7 @@ impl CmdArgument for Vec<String> {
 /// ```
 /// use stir::*;
 ///
-/// let output: String = cmd!(["echo", "foo"]);
+/// let Stdout(output) = cmd!(["echo", "foo"]);
 /// assert_eq!(output, "foo\n");
 /// ```
 #[rustversion::since(1.51)]
@@ -134,7 +134,7 @@ pub struct CurrentDir<T: AsRef<Path>>(pub T);
 ///
 /// # #[cfg(target_os = "linux")]
 /// # {
-/// let output: String = cmd!("pwd", CurrentDir("/tmp"));
+/// let Stdout(output) = cmd!("pwd", CurrentDir("/tmp"));
 /// assert_eq!(output, "/tmp\n");
 /// # }
 /// ```

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -69,7 +69,7 @@ impl CmdArgument for Vec<String> {
 /// ```
 /// use stir::*;
 ///
-/// let Stdout(output) = cmd!(["echo", "foo"]);
+/// let StdoutUntrimmed(output) = cmd!(["echo", "foo"]);
 /// assert_eq!(output, "foo\n");
 /// ```
 #[rustversion::since(1.51)]
@@ -134,7 +134,7 @@ pub struct CurrentDir<T: AsRef<Path>>(pub T);
 ///
 /// # #[cfg(target_os = "linux")]
 /// # {
-/// let Stdout(output) = cmd!("pwd", CurrentDir("/tmp"));
+/// let StdoutUntrimmed(output) = cmd!("pwd", CurrentDir("/tmp"));
 /// assert_eq!(output, "/tmp\n");
 /// # }
 /// ```

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -64,11 +64,11 @@ pub struct StdoutTrimmed(pub String);
 /// ```
 impl CmdOutput for StdoutTrimmed {
     fn prepare_config(config: &mut Config) {
-        <StdoutUntrimmed as CmdOutput>::prepare_config(config);
+        StdoutUntrimmed::prepare_config(config);
     }
 
     fn from_run_result(config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
-        let StdoutUntrimmed(stdout) = CmdOutput::from_run_result(config, result)?;
+        let StdoutUntrimmed(stdout) = StdoutUntrimmed::from_run_result(config, result)?;
         Ok(StdoutTrimmed(stdout.trim().to_owned()))
     }
 }

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -38,14 +38,25 @@ impl CmdOutput for () {
     }
 }
 
-/// Please, see the [`CmdOutput`] implementation for [`Stdout`] below.
+/// See the [`CmdOutput`] implementation for [`Stdout`] below.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Stdout(pub String);
 
 /// Returns what the child process writes to `stdout`, interpreted as utf-8,
 /// collected into a string. This also suppresses output of the child's `stdout`
-/// to the parent's `stdout`. (Which would be the default when not using [`String`]
+/// to the parent's `stdout`. (Which would be the default when not using [`Stdout`]
 /// as the return value.)
+///
+/// It's recommended to pattern-match to get to the inner [`String`].
+/// This will make sure that the return type can be inferred.
+/// Here's an example:
+///
+/// ```
+/// use stir::*;
+///
+/// let Stdout(output) = cmd!("echo foo");
+/// assert_eq!(output, "foo\n");
+/// ```
 impl CmdOutput for Stdout {
     #[doc(hidden)]
     fn prepare_config(config: &mut Config) {

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -45,7 +45,7 @@ pub struct StdoutTrimmed(pub String);
 /// Returns what the child process writes to `stdout`, interpreted as utf-8,
 /// collected into a string, trimmed of leading and trailing whitespace.
 /// This also suppresses output of the child's `stdout`
-/// to the parent's `stdout`. (Which would be the default when not using [`StdoutUntrimmed`]
+/// to the parent's `stdout`. (Which would be the default when not using [`StdoutTrimmed`]
 /// as the return value.)
 ///
 /// It's recommended to pattern-match to get to the inner [`String`].

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -14,7 +14,7 @@ use std::process::ExitStatus;
 /// ```
 /// use stir::*;
 ///
-/// let (Stdout(stdout), Exit(status)) = cmd!("echo foo");
+/// let (StdoutUntrimmed(stdout), Exit(status)) = cmd!("echo foo");
 /// assert_eq!(stdout, "foo\n");
 /// assert!(status.success());
 /// ```
@@ -38,13 +38,13 @@ impl CmdOutput for () {
     }
 }
 
-/// See the [`CmdOutput`] implementation for [`Stdout`] below.
+/// See the [`CmdOutput`] implementation for [`StdoutUntrimmed`] below.
 #[derive(Debug, PartialEq, Clone)]
-pub struct Stdout(pub String);
+pub struct StdoutUntrimmed(pub String);
 
 /// Returns what the child process writes to `stdout`, interpreted as utf-8,
 /// collected into a string. This also suppresses output of the child's `stdout`
-/// to the parent's `stdout`. (Which would be the default when not using [`Stdout`]
+/// to the parent's `stdout`. (Which would be the default when not using [`StdoutUntrimmed`]
 /// as the return value.)
 ///
 /// It's recommended to pattern-match to get to the inner [`String`].
@@ -54,10 +54,10 @@ pub struct Stdout(pub String);
 /// ```
 /// use stir::*;
 ///
-/// let Stdout(output) = cmd!("echo foo");
+/// let StdoutUntrimmed(output) = cmd!("echo foo");
 /// assert_eq!(output, "foo\n");
 /// ```
-impl CmdOutput for Stdout {
+impl CmdOutput for StdoutUntrimmed {
     #[doc(hidden)]
     fn prepare_config(config: &mut Config) {
         config.relay_stdout = false;
@@ -66,11 +66,11 @@ impl CmdOutput for Stdout {
     #[doc(hidden)]
     fn from_run_result(config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
         let result = result?;
-        Ok(Stdout(String::from_utf8(result.stdout).map_err(|_| {
-            Error::InvalidUtf8ToStdout {
+        Ok(StdoutUntrimmed(String::from_utf8(result.stdout).map_err(
+            |_| Error::InvalidUtf8ToStdout {
                 full_command: config.full_command(),
-            }
-        })?))
+            },
+        )?))
     }
 }
 

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -56,8 +56,11 @@ pub struct StdoutTrimmed(pub String);
 /// use std::path::Path;
 /// use stir::*;
 ///
+/// # #[cfg(unix)]
+/// # {
 /// let StdoutTrimmed(output) = cmd!("which ls");
 /// assert!(Path::new(&output).exists());
+/// # }
 /// ```
 impl CmdOutput for StdoutTrimmed {
     fn prepare_config(config: &mut Config) {

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -74,6 +74,31 @@ impl CmdOutput for StdoutUntrimmed {
     }
 }
 
+/// See the [`CmdOutput`] implementation for [`StdoutTrimmed`] below.
+#[derive(Debug, PartialEq, Clone)]
+pub struct StdoutTrimmed(pub String);
+
+/// Same as [`StdoutUntrimmed`], but trims both leading and trailing whitespace
+/// from the output. This can be useful to e.g. retrieve file paths:
+///
+/// ```
+/// use std::path::Path;
+/// use stir::*;
+///
+/// let StdoutTrimmed(output) = cmd!("which ls");
+/// assert!(Path::new(&output).exists());
+/// ```
+impl CmdOutput for StdoutTrimmed {
+    fn prepare_config(config: &mut Config) {
+        <StdoutUntrimmed as CmdOutput>::prepare_config(config);
+    }
+
+    fn from_run_result(config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
+        let StdoutUntrimmed(stdout) = CmdOutput::from_run_result(config, result)?;
+        Ok(StdoutTrimmed(stdout.trim().to_owned()))
+    }
+}
+
 macro_rules! tuple_impl {
     ($($generics:ident,)+) => {
         impl<$($generics),+> CmdOutput for ($($generics,)+)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,7 +602,7 @@ mod tests {
     fn array_refs_as_arguments() {
         let args: &[&str; 2] = &["echo", "foo"];
         let StdoutTrimmed(stdout) = cmd!(args);
-        assert_eq!(stdout, "foo\n");
+        assert_eq!(stdout, "foo");
     }
 
     #[rustversion::since(1.51)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,12 +464,12 @@ mod tests {
 
             #[test]
             fn no_errors() {
-                let result: Result<(), Error> = cmd_result!("true");
-                result.unwrap();
+                let () = cmd_result!("true").unwrap();
             }
 
             #[test]
             fn combine_ok_with_other_outputs() {
+                // todo: use method
                 let result: Result<Stdout, Error> = cmd_result!("echo -n foo");
                 assert_eq!(result.unwrap().0, "foo".to_string());
             }
@@ -887,8 +887,8 @@ mod tests {
 
         #[test]
         fn failing_commands_return_oks_when_exit_status_is_captured() {
-            let result: Result<Exit, Error> = cmd_result!("false");
-            assert!(!result.unwrap().0.success());
+            let Exit(status) = cmd_result!("false").unwrap();
+            assert!(!status.success());
         }
     }
 
@@ -917,18 +917,14 @@ mod tests {
 
         #[test]
         fn result_of_tuple() {
-            // todo: simplify
-            let result: Result<(Stdout, Exit), Error> = cmd_result!("echo foo");
-            let (Stdout(output), Exit(status)) = result.unwrap();
+            let (Stdout(output), Exit(status)) = cmd_result!("echo foo").unwrap();
             assert_eq!(output, "foo\n");
             assert!(status.success());
         }
 
         #[test]
         fn result_of_tuple_when_erroring() {
-            // todo: simplify
-            let result: Result<(Stdout, Exit), Error> = cmd_result!("false");
-            let (Stdout(output), Exit(status)) = result.unwrap();
+            let (Stdout(output), Exit(status)) = cmd_result!("false").unwrap();
             assert_eq!(output, "");
             assert_eq!(status.code(), Some(1));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,8 @@ mod tests {
 
             #[test]
             fn no_errors() {
-                let () = cmd_result!("true").unwrap();
+                let result: Result<(), Error> = cmd_result!("true");
+                result.unwrap();
             }
 
             #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "cmd!: false:\n  exited with exit code: 1")]
             fn combine_panics_with_other_outputs() {
-                let StdoutUntrimmed(_) = cmd!("false");
+                let StdoutTrimmed(_) = cmd!("false");
             }
 
             #[test]
@@ -435,7 +435,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "invalid utf-8 written to stdout")]
             fn invalid_utf8_stdout() {
-                let StdoutUntrimmed(_) = cmd!(
+                let StdoutTrimmed(_) = cmd!(
                     executable_path("stir_test_helper").to_str().unwrap(),
                     vec!["invalid utf-8 stdout"]
                 );
@@ -477,7 +477,7 @@ mod tests {
 
             #[test]
             fn combine_err_with_other_outputs() {
-                let result: Result<StdoutUntrimmed, Error> = cmd_result!("false");
+                let result: Result<StdoutTrimmed, Error> = cmd_result!("false");
                 assert_eq!(
                     result.unwrap_err().to_string(),
                     "false:\n  exited with exit code: 1"
@@ -541,7 +541,7 @@ mod tests {
             fn invalid_utf8_stdout() {
                 let test_helper = executable_path("stir_test_helper");
                 let test_helper = test_helper.to_str().unwrap();
-                let result: Result<StdoutUntrimmed, Error> =
+                let result: Result<StdoutTrimmed, Error> =
                     cmd_result!(test_helper, vec!["invalid utf-8 stdout"]);
                 assert_eq!(
                     result.unwrap_err().to_string(),
@@ -556,35 +556,35 @@ mod tests {
 
     #[test]
     fn allows_to_retrieve_stdout() {
-        let StdoutUntrimmed(stdout) = cmd!("echo foo");
-        assert_eq!(stdout, "foo\n");
+        let StdoutTrimmed(stdout) = cmd!("echo foo");
+        assert_eq!(stdout, "foo");
     }
 
     #[test]
     fn command_and_argument_as_separate_ref_str() {
-        let StdoutUntrimmed(stdout) = cmd!("echo", "foo");
-        assert_eq!(stdout, "foo\n");
+        let StdoutTrimmed(stdout) = cmd!("echo", "foo");
+        assert_eq!(stdout, "foo");
     }
 
     #[test]
     fn multiple_arguments_as_ref_str() {
-        let StdoutUntrimmed(stdout) = cmd!("echo", "foo", "bar");
-        assert_eq!(stdout, "foo bar\n");
+        let StdoutTrimmed(stdout) = cmd!("echo", "foo", "bar");
+        assert_eq!(stdout, "foo bar");
     }
 
     #[test]
     fn allows_to_pass_in_arguments_as_a_vec_of_ref_str() {
         let args: Vec<&str> = vec!["foo"];
-        let StdoutUntrimmed(stdout) = cmd!("echo", args);
-        assert_eq!(stdout, "foo\n");
+        let StdoutTrimmed(stdout) = cmd!("echo", args);
+        assert_eq!(stdout, "foo");
     }
 
     #[rustversion::since(1.51)]
     #[test]
     fn arrays_as_arguments() {
         let args: [&str; 2] = ["echo", "foo"];
-        let StdoutUntrimmed(stdout) = cmd!(args);
-        assert_eq!(stdout, "foo\n");
+        let StdoutTrimmed(stdout) = cmd!(args);
+        assert_eq!(stdout, "foo");
     }
 
     #[rustversion::since(1.51)]
@@ -601,7 +601,7 @@ mod tests {
     #[test]
     fn array_refs_as_arguments() {
         let args: &[&str; 2] = &["echo", "foo"];
-        let StdoutUntrimmed(stdout) = cmd!(args);
+        let StdoutTrimmed(stdout) = cmd!(args);
         assert_eq!(stdout, "foo\n");
     }
 
@@ -618,8 +618,8 @@ mod tests {
     #[test]
     fn slices_as_arguments() {
         let args: &[&str] = &["echo", "foo"];
-        let StdoutUntrimmed(stdout) = cmd!(args);
-        assert_eq!(stdout, "foo\n");
+        let StdoutTrimmed(stdout) = cmd!(args);
+        assert_eq!(stdout, "foo");
     }
 
     #[test]
@@ -643,23 +643,23 @@ mod tests {
         #[test]
         fn splits_strings_into_words() {
             let command: String = "echo foo".to_string();
-            let StdoutUntrimmed(output) = cmd!(command);
-            assert_eq!(output, "foo\n");
+            let StdoutTrimmed(output) = cmd!(command);
+            assert_eq!(output, "foo");
         }
 
         #[test]
         fn multiple_strings() {
             let command: String = "echo".to_string();
             let argument: String = "foo".to_string();
-            let StdoutUntrimmed(output) = cmd!(command, argument);
-            assert_eq!(output, "foo\n");
+            let StdoutTrimmed(output) = cmd!(command, argument);
+            assert_eq!(output, "foo");
         }
 
         #[test]
         fn mix_ref_str_and_string() {
             let argument: String = "foo".to_string();
-            let StdoutUntrimmed(output) = cmd!("echo", argument);
-            assert_eq!(output, "foo\n");
+            let StdoutTrimmed(output) = cmd!("echo", argument);
+            assert_eq!(output, "foo");
         }
 
         #[test]
@@ -718,14 +718,14 @@ mod tests {
         #[test]
         fn does_not_relay_stdout_when_collecting_into_string() {
             let context = Context::test();
-            let StdoutUntrimmed(_) = cmd_result_with_context!(context.clone(), "echo foo").unwrap();
+            let StdoutTrimmed(_) = cmd_result_with_context!(context.clone(), "echo foo").unwrap();
             assert_eq!(context.stdout(), "");
         }
 
         #[test]
         fn does_not_relay_stdout_when_collecting_into_result_of_string() {
             let context = Context::test();
-            let _: Result<StdoutUntrimmed, Error> =
+            let _: Result<StdoutTrimmed, Error> =
                 cmd_result_with_context!(context.clone(), "echo foo");
             assert_eq!(context.stdout(), "");
         }
@@ -899,54 +899,54 @@ mod tests {
 
         #[test]
         fn two_tuple_1() {
-            let (StdoutUntrimmed(output), Exit(status)) = cmd!(
+            let (StdoutTrimmed(output), Exit(status)) = cmd!(
                 executable_path("stir_test_helper").to_str().unwrap(),
                 vec!["output foo and exit with 42"]
             );
-            assert_eq!(output, "foo\n");
+            assert_eq!(output, "foo");
             assert_eq!(status.code(), Some(42));
         }
 
         #[test]
         fn two_tuple_2() {
-            let (Exit(status), StdoutUntrimmed(output)) = cmd!(
+            let (Exit(status), StdoutTrimmed(output)) = cmd!(
                 executable_path("stir_test_helper").to_str().unwrap(),
                 vec!["output foo and exit with 42"]
             );
-            assert_eq!(output, "foo\n");
+            assert_eq!(output, "foo");
             assert_eq!(status.code(), Some(42));
         }
 
         #[test]
         fn result_of_tuple() {
-            let (StdoutUntrimmed(output), Exit(status)) = cmd_result!("echo foo").unwrap();
-            assert_eq!(output, "foo\n");
+            let (StdoutTrimmed(output), Exit(status)) = cmd_result!("echo foo").unwrap();
+            assert_eq!(output, "foo");
             assert!(status.success());
         }
 
         #[test]
         fn result_of_tuple_when_erroring() {
-            let (StdoutUntrimmed(output), Exit(status)) = cmd_result!("false").unwrap();
+            let (StdoutTrimmed(output), Exit(status)) = cmd_result!("false").unwrap();
             assert_eq!(output, "");
             assert_eq!(status.code(), Some(1));
         }
 
         #[test]
         fn three_tuples() {
-            let (Stderr(stderr), StdoutUntrimmed(stdout), Exit(status)) = cmd!("echo foo");
+            let (Stderr(stderr), StdoutTrimmed(stdout), Exit(status)) = cmd!("echo foo");
             assert_eq!(stderr, "");
-            assert_eq!(stdout, "foo\n");
+            assert_eq!(stdout, "foo");
             assert_eq!(status.code(), Some(0));
         }
 
         #[test]
         fn capturing_stdout_on_errors() {
-            let (StdoutUntrimmed(output), Exit(status)) = cmd!(
+            let (StdoutTrimmed(output), Exit(status)) = cmd!(
                 executable_path("stir_test_helper").to_str().unwrap(),
                 vec!["output foo and exit with 42"]
             );
             assert!(!status.success());
-            assert_eq!(output, "foo\n");
+            assert_eq!(output, "foo");
         }
 
         #[test]
@@ -989,38 +989,67 @@ mod tests {
         }
     }
 
-    mod stdout_trimmed {
+    mod capturing_stdout {
         use super::*;
 
-        #[test]
-        fn trims_trailing_whitespace() {
-            let StdoutTrimmed(output) = cmd!("echo foo");
-            assert_eq!(output, "foo");
+        mod trimmed {
+            use super::*;
+
+            #[test]
+            fn trims_trailing_whitespace() {
+                let StdoutTrimmed(output) = cmd!("echo foo");
+                assert_eq!(output, "foo");
+            }
+
+            #[test]
+            fn trims_leading_whitespace() {
+                let StdoutTrimmed(output) = cmd!("echo -n", vec![" foo"]);
+                assert_eq!(output, "foo");
+            }
+
+            #[test]
+            fn does_not_remove_whitespace_within_output() {
+                let StdoutTrimmed(output) = cmd!("echo -n", vec!["foo bar"]);
+                assert_eq!(output, "foo bar");
+            }
+
+            #[test]
+            fn does_not_modify_output_without_whitespace() {
+                let StdoutTrimmed(output) = cmd!("echo -n foo");
+                assert_eq!(output, "foo");
+            }
+
+            #[test]
+            fn does_not_relay_stdout() {
+                let context = Context::test();
+                let StdoutTrimmed(_) =
+                    cmd_result_with_context!(context.clone(), "echo foo").unwrap();
+                assert_eq!(context.stdout(), "");
+            }
         }
 
-        #[test]
-        fn trims_leading_whitespace() {
-            let StdoutTrimmed(output) = cmd!("echo -n", vec![" foo"]);
-            assert_eq!(output, "foo");
-        }
+        mod untrimmed {
+            use super::*;
 
-        #[test]
-        fn does_not_remove_whitespace_within_output() {
-            let StdoutTrimmed(output) = cmd!("echo -n", vec!["foo bar"]);
-            assert_eq!(output, "foo bar");
-        }
+            #[test]
+            fn does_not_trim_trailing_newline() {
+                let StdoutUntrimmed(output) = cmd!("echo foo");
+                assert_eq!(output, "foo\n");
+            }
 
-        #[test]
-        fn does_not_modify_output_without_whitespace() {
-            let StdoutTrimmed(output) = cmd!("echo -n foo");
-            assert_eq!(output, "foo");
-        }
+            #[test]
+            fn does_not_trim_leading_whitespace() {
+                let StdoutUntrimmed(output) = cmd!("echo -n", vec![" foo"]);
+                assert_eq!(output, " foo");
+            }
 
-        #[test]
-        fn does_not_relay_stdout_when_collecting_into_trimmed_string() {
-            let context = Context::test();
-            let StdoutTrimmed(_) = cmd_result_with_context!(context.clone(), "echo foo").unwrap();
-            assert_eq!(context.stdout(), "");
+            #[test]
+            fn does_not_relay_stdout() {
+                let context = Context::test();
+                let StdoutUntrimmed(_) =
+                    cmd_result_with_context!(context.clone(), "echo foo").unwrap();
+                assert_eq!(context.stdout(), "");
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! ```
 //! use stir::*;
 //!
-//! let Stdout(stdout) = cmd!("echo -n foo");
+//! let StdoutUntrimmed(stdout) = cmd!("echo -n foo");
 //! assert_eq!(stdout, "foo");
 //! ```
 //!
@@ -17,7 +17,7 @@
 //! ```
 //! use stir::*;
 //!
-//! let Stdout(stdout) = cmd!("echo", "foo", "bar");
+//! let StdoutUntrimmed(stdout) = cmd!("echo", "foo", "bar");
 //! assert_eq!(stdout, "foo bar\n");
 //! ```
 //!
@@ -30,7 +30,7 @@
 //!
 //! # #[rustversion::since(1.51)]
 //! # fn test() {
-//! let Stdout(stdout) = cmd!("echo", ["foo", "bar"]);
+//! let StdoutUntrimmed(stdout) = cmd!("echo", ["foo", "bar"]);
 //! assert_eq!(stdout, "foo bar\n");
 //! # }
 //! # #[rustversion::before(1.51)]
@@ -47,7 +47,7 @@
 //!
 //! # #[rustversion::since(1.51)]
 //! # fn test() {
-//! let Stdout(_) = cmd!("touch", ["filename with spaces"]);
+//! let StdoutUntrimmed(_) = cmd!("touch", ["filename with spaces"]);
 //! assert!(PathBuf::from("filename with spaces").exists());
 //! # }
 //! # #[rustversion::before(1.51)]
@@ -61,7 +61,7 @@
 //! use std::path::PathBuf;
 //! use stir::*;
 //!
-//! let Stdout(_) = cmd!("touch", vec!["filename with spaces"]);
+//! let StdoutUntrimmed(_) = cmd!("touch", vec!["filename with spaces"]);
 //! assert!(PathBuf::from("filename with spaces").exists());
 //! ```
 //!
@@ -71,18 +71,18 @@
 //!
 //! You can choose which return type you want [`cmd!`] to return,
 //! as long as the chosen return type implements [`CmdOutput`].
-//! For example you can use e.g. [`Stdout`] to collect what the
+//! For example you can use e.g. [`StdoutUntrimmed`] to collect what the
 //! child process writes to `stdout`:
 //!
 //! ```
 //! use stir::*;
 //!
-//! let Stdout(output) = cmd!("echo foo");
+//! let StdoutUntrimmed(output) = cmd!("echo foo");
 //! assert_eq!(output, "foo\n");
 //! ```
 //!
 //! (By default, the child's `stdout` is written to the parent's `stdout`.
-//! Using `Stdout` as the return type suppresses that.)
+//! Using `StdoutUntrimmed` as the return type suppresses that.)
 //!
 //! If you don't want any result from [`cmd!`], you can use `()`
 //! as the return value:
@@ -149,7 +149,7 @@
 //! );
 //!
 //! let result = cmd_result!("echo foo");
-//! let Stdout(output) = result.unwrap();
+//! let StdoutUntrimmed(output) = result.unwrap();
 //! assert_eq!(output, "foo\n".to_string());
 //! ```
 //!
@@ -178,7 +178,7 @@ mod error;
 use crate::collected_output::Waiter;
 pub use crate::{
     cmd_argument::{CmdArgument, CurrentDir, LogCommand},
-    cmd_output::{CmdOutput, Exit, Stderr, Stdout},
+    cmd_output::{CmdOutput, Exit, Stderr, StdoutUntrimmed},
     error::{panic_on_error, Error},
 };
 #[doc(hidden)]
@@ -373,7 +373,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "cmd!: false:\n  exited with exit code: 1")]
             fn combine_panics_with_other_outputs() {
-                let Stdout(_) = cmd!("false");
+                let StdoutUntrimmed(_) = cmd!("false");
             }
 
             #[test]
@@ -434,7 +434,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "invalid utf-8 written to stdout")]
             fn invalid_utf8_stdout() {
-                let Stdout(_) = cmd!(
+                let StdoutUntrimmed(_) = cmd!(
                     executable_path("stir_test_helper").to_str().unwrap(),
                     vec!["invalid utf-8 stdout"]
                 );
@@ -470,13 +470,13 @@ mod tests {
             #[test]
             fn combine_ok_with_other_outputs() {
                 let result = cmd_result!("echo -n foo");
-                let Stdout(output) = result.unwrap();
+                let StdoutUntrimmed(output) = result.unwrap();
                 assert_eq!(output, "foo".to_string());
             }
 
             #[test]
             fn combine_err_with_other_outputs() {
-                let result: Result<Stdout, Error> = cmd_result!("false");
+                let result: Result<StdoutUntrimmed, Error> = cmd_result!("false");
                 assert_eq!(
                     result.unwrap_err().to_string(),
                     "false:\n  exited with exit code: 1"
@@ -540,7 +540,7 @@ mod tests {
             fn invalid_utf8_stdout() {
                 let test_helper = executable_path("stir_test_helper");
                 let test_helper = test_helper.to_str().unwrap();
-                let result: Result<Stdout, Error> =
+                let result: Result<StdoutUntrimmed, Error> =
                     cmd_result!(test_helper, vec!["invalid utf-8 stdout"]);
                 assert_eq!(
                     result.unwrap_err().to_string(),
@@ -555,26 +555,26 @@ mod tests {
 
     #[test]
     fn allows_to_retrieve_stdout() {
-        let Stdout(stdout) = cmd!("echo foo");
+        let StdoutUntrimmed(stdout) = cmd!("echo foo");
         assert_eq!(stdout, "foo\n");
     }
 
     #[test]
     fn command_and_argument_as_separate_ref_str() {
-        let Stdout(stdout) = cmd!("echo", "foo");
+        let StdoutUntrimmed(stdout) = cmd!("echo", "foo");
         assert_eq!(stdout, "foo\n");
     }
 
     #[test]
     fn multiple_arguments_as_ref_str() {
-        let Stdout(stdout) = cmd!("echo", "foo", "bar");
+        let StdoutUntrimmed(stdout) = cmd!("echo", "foo", "bar");
         assert_eq!(stdout, "foo bar\n");
     }
 
     #[test]
     fn allows_to_pass_in_arguments_as_a_vec_of_ref_str() {
         let args: Vec<&str> = vec!["foo"];
-        let Stdout(stdout) = cmd!("echo", args);
+        let StdoutUntrimmed(stdout) = cmd!("echo", args);
         assert_eq!(stdout, "foo\n");
     }
 
@@ -582,7 +582,7 @@ mod tests {
     #[test]
     fn arrays_as_arguments() {
         let args: [&str; 2] = ["echo", "foo"];
-        let Stdout(stdout) = cmd!(args);
+        let StdoutUntrimmed(stdout) = cmd!(args);
         assert_eq!(stdout, "foo\n");
     }
 
@@ -600,7 +600,7 @@ mod tests {
     #[test]
     fn array_refs_as_arguments() {
         let args: &[&str; 2] = &["echo", "foo"];
-        let Stdout(stdout) = cmd!(args);
+        let StdoutUntrimmed(stdout) = cmd!(args);
         assert_eq!(stdout, "foo\n");
     }
 
@@ -617,7 +617,7 @@ mod tests {
     #[test]
     fn slices_as_arguments() {
         let args: &[&str] = &["echo", "foo"];
-        let Stdout(stdout) = cmd!(args);
+        let StdoutUntrimmed(stdout) = cmd!(args);
         assert_eq!(stdout, "foo\n");
     }
 
@@ -642,7 +642,7 @@ mod tests {
         #[test]
         fn splits_strings_into_words() {
             let command: String = "echo foo".to_string();
-            let Stdout(output) = cmd!(command);
+            let StdoutUntrimmed(output) = cmd!(command);
             assert_eq!(output, "foo\n");
         }
 
@@ -650,14 +650,14 @@ mod tests {
         fn multiple_strings() {
             let command: String = "echo".to_string();
             let argument: String = "foo".to_string();
-            let Stdout(output) = cmd!(command, argument);
+            let StdoutUntrimmed(output) = cmd!(command, argument);
             assert_eq!(output, "foo\n");
         }
 
         #[test]
         fn mix_ref_str_and_string() {
             let argument: String = "foo".to_string();
-            let Stdout(output) = cmd!("echo", argument);
+            let StdoutUntrimmed(output) = cmd!("echo", argument);
             assert_eq!(output, "foo\n");
         }
 
@@ -717,14 +717,15 @@ mod tests {
         #[test]
         fn does_not_relay_stdout_when_collecting_into_string() {
             let context = Context::test();
-            let Stdout(_) = cmd_result_with_context!(context.clone(), "echo foo").unwrap();
+            let StdoutUntrimmed(_) = cmd_result_with_context!(context.clone(), "echo foo").unwrap();
             assert_eq!(context.stdout(), "");
         }
 
         #[test]
         fn does_not_relay_stdout_when_collecting_into_result_of_string() {
             let context = Context::test();
-            let _: Result<Stdout, Error> = cmd_result_with_context!(context.clone(), "echo foo");
+            let _: Result<StdoutUntrimmed, Error> =
+                cmd_result_with_context!(context.clone(), "echo foo");
             assert_eq!(context.stdout(), "");
         }
     }
@@ -897,7 +898,7 @@ mod tests {
 
         #[test]
         fn two_tuple_1() {
-            let (Stdout(output), Exit(status)) = cmd!(
+            let (StdoutUntrimmed(output), Exit(status)) = cmd!(
                 executable_path("stir_test_helper").to_str().unwrap(),
                 vec!["output foo and exit with 42"]
             );
@@ -907,7 +908,7 @@ mod tests {
 
         #[test]
         fn two_tuple_2() {
-            let (Exit(status), Stdout(output)) = cmd!(
+            let (Exit(status), StdoutUntrimmed(output)) = cmd!(
                 executable_path("stir_test_helper").to_str().unwrap(),
                 vec!["output foo and exit with 42"]
             );
@@ -917,21 +918,21 @@ mod tests {
 
         #[test]
         fn result_of_tuple() {
-            let (Stdout(output), Exit(status)) = cmd_result!("echo foo").unwrap();
+            let (StdoutUntrimmed(output), Exit(status)) = cmd_result!("echo foo").unwrap();
             assert_eq!(output, "foo\n");
             assert!(status.success());
         }
 
         #[test]
         fn result_of_tuple_when_erroring() {
-            let (Stdout(output), Exit(status)) = cmd_result!("false").unwrap();
+            let (StdoutUntrimmed(output), Exit(status)) = cmd_result!("false").unwrap();
             assert_eq!(output, "");
             assert_eq!(status.code(), Some(1));
         }
 
         #[test]
         fn three_tuples() {
-            let (Stderr(stderr), Stdout(stdout), Exit(status)) = cmd!("echo foo");
+            let (Stderr(stderr), StdoutUntrimmed(stdout), Exit(status)) = cmd!("echo foo");
             assert_eq!(stderr, "");
             assert_eq!(stdout, "foo\n");
             assert_eq!(status.code(), Some(0));
@@ -939,7 +940,7 @@ mod tests {
 
         #[test]
         fn capturing_stdout_on_errors() {
-            let (Stdout(output), Exit(status)) = cmd!(
+            let (StdoutUntrimmed(output), Exit(status)) = cmd!(
                 executable_path("stir_test_helper").to_str().unwrap(),
                 vec!["output foo and exit with 42"]
             );
@@ -968,7 +969,7 @@ mod tests {
                 fs::create_dir("dir").unwrap();
                 fs::write("dir/file", "foo").unwrap();
                 fs::write("file", "wrong file").unwrap();
-                let Stdout(output) = cmd!("cat file", CurrentDir("dir"));
+                let StdoutUntrimmed(output) = cmd!("cat file", CurrentDir("dir"));
                 assert_eq!(output, "foo");
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,9 +469,9 @@ mod tests {
 
             #[test]
             fn combine_ok_with_other_outputs() {
-                // todo: use method
-                let result: Result<Stdout, Error> = cmd_result!("echo -n foo");
-                assert_eq!(result.unwrap().0, "foo".to_string());
+                let result = cmd_result!("echo -n foo");
+                let Stdout(output) = result.unwrap();
+                assert_eq!(output, "foo".to_string());
             }
 
             #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -999,13 +999,13 @@ mod tests {
 
         #[test]
         fn trims_leading_whitespace() {
-            let StdoutTrimmed(output) = cmd!("echo -n", [" foo"]);
+            let StdoutTrimmed(output) = cmd!("echo -n", vec![" foo"]);
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn does_not_remove_whitespace_within_output() {
-            let StdoutTrimmed(output) = cmd!("echo -n", ["foo bar"]);
+            let StdoutTrimmed(output) = cmd!("echo -n", vec!["foo bar"]);
             assert_eq!(output, "foo bar");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //!
 //! You can choose which return type you want [`cmd!`] to return,
 //! as long as the chosen return type implements [`CmdOutput`].
-//! For example you can use e.g. [`String`] to collect what the
+//! For example you can use e.g. [`Stdout`] to collect what the
 //! child process writes to `stdout`:
 //!
 //! ```
@@ -82,7 +82,7 @@
 //! ```
 //!
 //! (By default, the child's `stdout` is written to the parent's `stdout`.
-//! Using `String` as the return type suppresses that.)
+//! Using `Stdout` as the return type suppresses that.)
 //!
 //! If you don't want any result from [`cmd!`], you can use `()`
 //! as the return value:
@@ -148,9 +148,9 @@
 //!     "false:\n  exited with exit code: 1"
 //! );
 //!
-//! let result: Result<Stdout, stir::Error> = cmd_result!("echo foo");
-//! // todo: use method
-//! assert_eq!(result.unwrap().0, "foo\n".to_string());
+//! let result = cmd_result!("echo foo");
+//! let Stdout(output) = result.unwrap();
+//! assert_eq!(output, "foo\n".to_string());
 //! ```
 //!
 //! [`cmd_result`] can also be combined with `?` to handle errors in an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! `stir` provides the [`cmd!`] macro, that makes
-//! it easy to run commands from rust programs.
+//! it easy to run child processes from rust programs.
 //!
 //! ```
 //! use stir::*;
 //!
-//! let StdoutUntrimmed(stdout) = cmd!("echo -n foo");
+//! let StdoutTrimmed(stdout) = cmd!("echo foo");
 //! assert_eq!(stdout, "foo");
 //! ```
 //!
@@ -17,8 +17,8 @@
 //! ```
 //! use stir::*;
 //!
-//! let StdoutUntrimmed(stdout) = cmd!("echo", "foo", "bar");
-//! assert_eq!(stdout, "foo bar\n");
+//! let StdoutTrimmed(stdout) = cmd!("echo", "foo", "bar");
+//! assert_eq!(stdout, "foo bar");
 //! ```
 //!
 //! Arguments of type [`&str`] will be split by whitespace into words.
@@ -30,8 +30,8 @@
 //!
 //! # #[rustversion::since(1.51)]
 //! # fn test() {
-//! let StdoutUntrimmed(stdout) = cmd!("echo", ["foo", "bar"]);
-//! assert_eq!(stdout, "foo bar\n");
+//! let StdoutTrimmed(stdout) = cmd!("echo", ["foo", "bar"]);
+//! assert_eq!(stdout, "foo bar");
 //! # }
 //! # #[rustversion::before(1.51)]
 //! # fn test() {}
@@ -47,7 +47,7 @@
 //!
 //! # #[rustversion::since(1.51)]
 //! # fn test() {
-//! let StdoutUntrimmed(_) = cmd!("touch", ["filename with spaces"]);
+//! let StdoutTrimmed(_) = cmd!("touch", ["filename with spaces"]);
 //! assert!(PathBuf::from("filename with spaces").exists());
 //! # }
 //! # #[rustversion::before(1.51)]
@@ -61,7 +61,7 @@
 //! use std::path::PathBuf;
 //! use stir::*;
 //!
-//! let StdoutUntrimmed(_) = cmd!("touch", vec!["filename with spaces"]);
+//! let StdoutTrimmed(_) = cmd!("touch", vec!["filename with spaces"]);
 //! assert!(PathBuf::from("filename with spaces").exists());
 //! ```
 //!
@@ -71,18 +71,19 @@
 //!
 //! You can choose which return type you want [`cmd!`] to return,
 //! as long as the chosen return type implements [`CmdOutput`].
-//! For example you can use e.g. [`StdoutUntrimmed`] to collect what the
-//! child process writes to `stdout`:
+//! For example you can use e.g. [`StdoutTrimmed`] to collect what the
+//! child process writes to `stdout`,
+//! trimmed of leading and trailing whitespace:
 //!
 //! ```
 //! use stir::*;
 //!
-//! let StdoutUntrimmed(output) = cmd!("echo foo");
-//! assert_eq!(output, "foo\n");
+//! let StdoutTrimmed(output) = cmd!("echo foo");
+//! assert_eq!(output, "foo");
 //! ```
 //!
 //! (By default, the child's `stdout` is written to the parent's `stdout`.
-//! Using `StdoutUntrimmed` as the return type suppresses that.)
+//! Using `StdoutTrimmed` as the return type suppresses that.)
 //!
 //! If you don't want any result from [`cmd!`], you can use `()`
 //! as the return value:
@@ -469,8 +470,7 @@ mod tests {
 
             #[test]
             fn combine_ok_with_other_outputs() {
-                let result = cmd_result!("echo -n foo");
-                let StdoutUntrimmed(output) = result.unwrap();
+                let StdoutTrimmed(output) = cmd_result!("echo foo").unwrap();
                 assert_eq!(output, "foo".to_string());
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,8 +150,8 @@
 //! );
 //!
 //! let result = cmd_result!("echo foo");
-//! let StdoutUntrimmed(output) = result.unwrap();
-//! assert_eq!(output, "foo\n".to_string());
+//! let StdoutTrimmed(output) = result.unwrap();
+//! assert_eq!(output, "foo".to_string());
 //! ```
 //!
 //! [`cmd_result`] can also be combined with `?` to handle errors in an

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,8 +9,8 @@ const WHICH: &str = "where";
 fn capturing_stdout() {
     use stir::*;
 
-    let StdoutUntrimmed(output) = cmd!("echo foo");
-    assert_eq!(output, "foo\n");
+    let StdoutTrimmed(output) = cmd!("echo foo");
+    assert_eq!(output, "foo");
 }
 
 #[test]
@@ -59,8 +59,7 @@ fn trimmed_stdout() {
     use stir::*;
 
     {
-        let StdoutUntrimmed(ls_path) = cmd!(WHICH, "ls");
-        let ls_path = ls_path.trim();
+        let StdoutTrimmed(ls_path) = cmd!(WHICH, "ls");
         assert!(
             PathBuf::from(&ls_path).exists(),
             "{:?} does not exist",
@@ -75,8 +74,7 @@ fn trimmed_stdout_and_results() {
     use stir::*;
 
     fn test() -> Result<(), Error> {
-        let StdoutUntrimmed(ls_path) = cmd_result!(WHICH, "ls")?;
-        let ls_path = ls_path.trim();
+        let StdoutTrimmed(ls_path) = cmd_result!(WHICH, "ls")?;
         assert!(
             PathBuf::from(&ls_path).exists(),
             "{:?} does not exist",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,7 +9,7 @@ const WHICH: &str = "where";
 fn capturing_stdout() {
     use stir::*;
 
-    let Stdout(output) = cmd!("echo foo");
+    let StdoutUntrimmed(output) = cmd!("echo foo");
     assert_eq!(output, "foo\n");
 }
 
@@ -59,7 +59,7 @@ fn trimmed_stdout() {
     use stir::*;
 
     {
-        let Stdout(ls_path) = cmd!(WHICH, "ls");
+        let StdoutUntrimmed(ls_path) = cmd!(WHICH, "ls");
         let ls_path = ls_path.trim();
         assert!(
             PathBuf::from(&ls_path).exists(),
@@ -75,7 +75,7 @@ fn trimmed_stdout_and_results() {
     use stir::*;
 
     fn test() -> Result<(), Error> {
-        let Stdout(ls_path) = cmd_result!(WHICH, "ls")?;
+        let StdoutUntrimmed(ls_path) = cmd_result!(WHICH, "ls")?;
         let ls_path = ls_path.trim();
         assert!(
             PathBuf::from(&ls_path).exists(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,7 +9,7 @@ const WHICH: &str = "where";
 fn capturing_stdout() {
     use stir::*;
 
-    let output: String = cmd!("echo foo");
+    let Stdout(output) = cmd!("echo foo");
     assert_eq!(output, "foo\n");
 }
 
@@ -59,7 +59,7 @@ fn trimmed_stdout() {
     use stir::*;
 
     {
-        let ls_path: String = cmd!(WHICH, "ls");
+        let Stdout(ls_path) = cmd!(WHICH, "ls");
         let ls_path = ls_path.trim();
         assert!(
             dbg!(PathBuf::from(&ls_path)).exists(),
@@ -75,7 +75,7 @@ fn trimmed_stdout_and_results() {
     use stir::*;
 
     fn test() -> Result<(), Error> {
-        let ls_path: String = cmd_result!(WHICH, "ls")?;
+        let Stdout(ls_path) = cmd_result!(WHICH, "ls")?;
         let ls_path = ls_path.trim();
         assert!(
             PathBuf::from(&ls_path).exists(),
@@ -182,4 +182,9 @@ fn user_supplied_errors_failing() {
             "cmd-error: where does-not-exist:\n  exited with exit code: 1"
         }
     );
+}
+
+#[test]
+fn pin_down_stdout_result_type_by_method() {
+    // todo
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -62,7 +62,7 @@ fn trimmed_stdout() {
         let Stdout(ls_path) = cmd!(WHICH, "ls");
         let ls_path = ls_path.trim();
         assert!(
-            dbg!(PathBuf::from(&ls_path)).exists(),
+            PathBuf::from(&ls_path).exists(),
             "{:?} does not exist",
             &ls_path
         );
@@ -182,9 +182,4 @@ fn user_supplied_errors_failing() {
             "cmd-error: where does-not-exist:\n  exited with exit code: 1"
         }
     );
-}
-
-#[test]
-fn pin_down_stdout_result_type_by_method() {
-    // todo
 }


### PR DESCRIPTION
This PR removes the `CmdOutput` impl for `String` and instead introduces 2 new-type wrappers around `String`: `StdoutUntrimmed` and `StdoutTrimmed`. They can be used like this:

```rust
use stir::*;

let StdoutTrimmed(ls_path) = cmd!("which ls");
let StdoutUntrimmed(output) = cmd!("cat some_file");
```

This is slightly less convenient than having a `String` impl, but it forces users to make a conscious decision about whether they want trimmed or untrimmed output. In my experience it happens often that I capture the `stdout` of a process, and try to do something with it, only to realize later that my program fails, because the output contains a trailing `\n`. This PR would help with that and probably save some time. 

For example this program type-checks with `stir` **before** this PR:

```rust
use stir::*;

fn main() {
  // start a container
  let container_id: String = cmd!("docker create ubuntu:latest");

  // do something with the container
  cmd_unit!("docker cp", format!("{}:/etc/lsb-release", container_id), "ubuntu-latest-lsb-release");
  cmd_unit!("cat ubuntu-latest-lsb-release");

  // shut down the container
  cmd_unit!("docker rm", container_id);
}
```

But it fails at runtime with this rather confusing error message:
```
"docker cp" requires exactly 2 arguments.
See 'docker cp --help'.

Usage:  docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
	docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH

Copy files/folders between a container and the local filesystem
thread 'main' panicked at 'cmd!: docker cp 81c66997c246a24cabb777eabe0d9c82e80769848998da94eb1f965dc2eaaa95 :/etc/lsb-release ubuntu-latest-lsb-release:
  exited with exit code: 1', /home/shahn/stir/src/error.rs:36:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The reason is, that `container_id` contains the container id *and* a trailing `\n`. This PR hopefully means that users will not run into these errors anymore.